### PR TITLE
feat: 사용자 정보 조회 api 연결

### DIFF
--- a/src/api/member-api.ts
+++ b/src/api/member-api.ts
@@ -1,0 +1,16 @@
+const BASE_URL = import.meta.env.VITE_BASE_URL;
+
+export const selectMemberData = async () => {
+  const response = await fetch(`${BASE_URL}/member`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`ERROR: ${response.status}`);
+  }
+
+  return response.json();
+};

--- a/src/components/attend-reward.tsx
+++ b/src/components/attend-reward.tsx
@@ -1,5 +1,4 @@
 /** @jsxImportSource @emotion/react */
-import { useEffect } from 'react';
 import { useSound } from '@context/sound-context';
 import type { ImagesProps } from '@pages/home';
 import {

--- a/src/components/attend.tsx
+++ b/src/components/attend.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @emotion/react */
 import AttendReward from './attend-reward';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import type { ImagesProps } from '@pages/home';
 import {
   attendCloseButtonCss,
@@ -12,26 +12,30 @@ import {
   attendTabCss,
   attendWrapperCss,
 } from '@styles/components/attend.css';
-import { getImage } from '@utils/get-images';
 
 type DayStatus = 'today' | 'claimed' | 'locked';
 
 interface AttendProps {
   handleAttend: () => void;
   images: ImagesProps;
+  todayCheckIn: boolean;
+  checkinStreak: number;
 }
 
-const Attend = ({ handleAttend, images }: AttendProps) => {
+const Attend = ({ handleAttend, images, todayCheckIn, checkinStreak }: AttendProps) => {
   const [reward, setReward] = useState<number>(-1);
-  const [statuses, setStatuses] = useState<DayStatus[]>([
-    'claimed',
-    'claimed',
-    'today',
-    'locked',
-    'locked',
-    'locked',
-    'locked',
-  ]);
+
+  const statuses: DayStatus[] = useMemo(() => {
+    return Array.from({ length: 7 }, (_, i) => {
+      if (i < checkinStreak) {
+        return 'claimed';
+      }
+      if (i === checkinStreak && !todayCheckIn) {
+        return 'today';
+      }
+      return 'locked';
+    });
+  }, [todayCheckIn, checkinStreak]);
 
   const getImages = Array.from({ length: 7 }, (_, i) => ({
     today: images[`check_day${i + 1}` as keyof ImagesProps],
@@ -60,7 +64,6 @@ const Attend = ({ handleAttend, images }: AttendProps) => {
 
   const handleRewardClose = () => {
     setReward(-1);
-    setStatuses((prev) => prev.map((status) => (status === 'today' ? 'claimed' : status)));
   };
 
   return (

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource @emotion/react */
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { selectMemberData } from '@api/member-api';
 import Attend from '@components/attend';
 import Guide from '@components/guide';
 import Option from '@components/option';
@@ -91,6 +92,16 @@ export interface ImagesProps {
   'SCARF-001': string;
 }
 
+interface MemberProps {
+  memberId: number;
+  coin: number;
+  checkinStreak: number;
+  todayCheckIn: boolean;
+  topRecord: number;
+  sound: boolean; // 백엔드 수정 필요
+  equipment: string[];
+}
+
 const Home = () => {
   const navigate = useNavigate();
   const [images, setImages] = useState<ImagesProps>({
@@ -161,6 +172,15 @@ const Home = () => {
     'ITEM-002': '',
     'SCARF-001': '',
   });
+  const [member, setMember] = useState<MemberProps>({
+    memberId: 0,
+    coin: 0,
+    checkinStreak: 0,
+    todayCheckIn: false,
+    topRecord: 0,
+    sound: true, // 백엔드 수정 필요
+    equipment: [],
+  });
 
   const [attend, setAttend] = useState<boolean>(false);
   const [shop, setShop] = useState<boolean>(false);
@@ -187,6 +207,29 @@ const Home = () => {
     return () => {
       window.removeEventListener('images:loaded', handleImages as EventListener);
     };
+  }, []);
+
+  useEffect(() => {
+    const getMemberData = async () => {
+      try {
+        const response = await selectMemberData();
+        setMember({
+          memberId: response.data.memberId,
+          coin: response.data.coin,
+          checkinStreak: response.data.checkinStreak,
+          todayCheckIn: response.data.todayCheckIn,
+          topRecord: response.data.topRecord,
+          sound: response.data.sound,
+          equipment: response.data.equipment,
+        });
+
+        return response;
+      } catch (error) {
+        console.log(error);
+      }
+    };
+
+    getMemberData();
   }, []);
 
   const handleAttend = () => {
@@ -238,13 +281,20 @@ const Home = () => {
   return (
     <>
       {transition && <div css={circleCss} />}
-      {attend && <Attend handleAttend={handleAttend} images={images} />}
+      {attend && (
+        <Attend
+          handleAttend={handleAttend}
+          images={images}
+          todayCehckIn={member.todayCheckIn}
+          checkinStreak={member.checkinStreak}
+        />
+      )}
       {shop && <Shop handleShop={handleShop} images={images} />}
       {guide && <Guide handleGameGuide={handleGameGuide} images={images} />}
       {option && <Option handleOption={handleOption} images={images} />}
       <div css={backgroundCss(images)}>
         <div css={coinCss}>
-          <span css={coinTextCss}>1985</span>
+          <span css={coinTextCss}>{member.coin}</span>
         </div>
         <div css={bestScoreCss}>
           <div css={bestScoreTextCss}>
@@ -252,7 +302,7 @@ const Home = () => {
             <span>최고기록</span>
             <img src={images.leaf_right} alt="오른쪽_장식_이미지" height={14} />
           </div>
-          <span css={bestScoreValueCss}>5853 m</span>
+          <span css={bestScoreValueCss}>{member.topRecord} m</span>
         </div>
         <div css={iconButtonGroupCss}>
           <div css={iconButtonListCss}>


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #47

### 💡 작업내용
- 사용자 정보 조회 api를 연결했습니다.

### 📸 스크린샷(선택)
<img width="360" alt="image" src="https://github.com/user-attachments/assets/4e4ba79f-4cf7-47a0-b494-dcbb97478dd4" />

(백에서 넣어둔 임시 사용자 데이터를 조회했습니다.)

### 📝 기타
(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)

- 현재 사운드, 아이템 장착에 대한 것은 적용되지 않았습니다. (전자는 백엔드 데이터 이슈, 후자는 상점 데이터와 연동 예정)
- 출석 체크의 경우도 관련 api 연결과 함께 마무리하겠습니다.